### PR TITLE
Create a public playback ID when creating asset

### DIFF
--- a/lib/api-utils.js
+++ b/lib/api-utils.js
@@ -115,14 +115,13 @@ export const getPublicFileUrl = async (urlPrivate) => {
   if (isVideo) {
     const asset = await Video.Assets.create({
       input: uploadedUrl,
+      playback_policy: 'public'
     })
-
-    const playback = await Video.Assets.createPlaybackId(asset.id, { policy: 'public' })
 
     return {
       url: uploadedUrl,
       muxId: asset.id,
-      muxPlaybackId: playback.id
+      muxPlaybackId: asset.playback_ids[0].id
     }
   }
   return {


### PR DESCRIPTION
* Make 1 API call to Mux instead of 2