### PR TITLE
Added Access-Control-Allow-Origin: * header

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,13 +8,10 @@
       "destination": "/api/users"
     }
   ],
-   "routes": [
+     "headers": [
     {
-      "src": "/(.*)",
-      "headers": {
-        "Access-Control-Allow-Origin": "*"
-      },
-      "continue": true
+      "source": "/(.*)",
+      "headers": [{ "key": "Access-Control-Allow-Origin", "value": "*" }]
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -7,5 +7,14 @@
       "source": "/api/profiles",
       "destination": "/api/users"
     }
+  ],
+   "routes": [
+    {
+      "src": "/(.*)",
+      "headers": {
+        "Access-Control-Allow-Origin": "*"
+      },
+      "continue": true
+    }
   ]
 }


### PR DESCRIPTION
I'm working on a thing that'll let you preview CSS customizations to your scrapbook in real-time by injecting the CSS into an iframe, but it didn't work cause of CORS restrictions. I have a workaround that's kinda working for now, but it'd be nice to have this header set instead.

Edit: I'm not quite sure if that was the right way to set headers.