### PR TITLE
Proper tooltip display with react-tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^16.13.1",
     "react-intersection-observer": "^8.26.2",
     "react-masonry-css": "^1.0.14",
+    "react-tooltip": "^4.2.9",
     "swr": "^0.2.3"
   }
 }

--- a/pages/[username]/index.js
+++ b/pages/[username]/index.js
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import Head from 'next/head'
 import Meta from '@hackclub/meta'
 import CalendarHeatmap from '@hackclub/react-calendar-heatmap'
+import dynamic from 'next/dynamic'
 import Icon from '@hackclub/icons'
 import Banner from '../../components/banner'
 import Message from '../../components/message'
@@ -16,6 +17,10 @@ import { clamp } from 'lodash'
 
 const HOST =
   process.env.NODE_ENV === 'development' ? '' : 'https://scrapbook.hackclub.com'
+
+const ReactTooltipNoSSR = dynamic(() => import('react-tooltip'), {
+  ssr: false
+})
 
 const Profile = ({
   profile = {},
@@ -150,10 +155,11 @@ const Profile = ({
           classForValue={v =>
             v?.count ? `color-${clamp(v.count, 1, 4)}` : 'color-empty'
           }
-          titleForValue={v =>
-            v?.date ? `${v?.date} updates: ${v?.count}` : ''
-          }
+          tooltipDataAttrs={v => ({
+            'data-tip': v?.date ? `${v?.date} updates: ${v?.count}` : ''
+          })}
         />
+        <ReactTooltipNoSSR />
       </aside>
     </header>
     <article className="posts">

--- a/yarn.lock
+++ b/yarn.lock
@@ -5232,6 +5232,14 @@ react-refresh@0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
+react-tooltip@^4.2.9:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.9.tgz#0dd08d14191f5d0e56b51c822fa20c2d81a24272"
+  integrity sha512-DgZyg5oxk9/orgePDLLeuDtlwwYv7CalJRahk9nNsoEJDzIO58GC6zSAet4bKTm6c01hg1z3EocP9H0nmMHTMA==
+  dependencies:
+    prop-types "^15.7.2"
+    uuid "^7.0.3"
+
 react@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
@@ -6407,6 +6415,11 @@ util@^0.11.0:
   integrity sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==
   dependencies:
     inherits "2.0.3"
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 vendors@^1.0.0:
   version "1.0.4"


### PR DESCRIPTION
The `titleOnValue` property in `react-calendar-heatmap` only works with the third party bootstrap tooltip library since it sets a `title` attribute instead of the SVG standard `<title>` tag. In any case, it appears the preferred method to implement the tooltip is with `react-tooltip` and the `tooltipDataAttrs` method instead as seen in https://github.com/kevinsqi/react-calendar-heatmap/blob/master/demo/src/Demo.js

`react-tooltip` doesn't play nicely with server side rendering, so we use a next/dynamic import to disable SSR for the `ReactTooltip` component.

Fixes #60 for real.