### PR TITLE
Add object-fit: cover; to images

### DIFF
--- a/public/themes/default.css
+++ b/public/themes/default.css
@@ -339,6 +339,7 @@ a.post-attachment {
 }
 .post-attachment img {
   height: 100%;
+  object-fit: cover;
 }
 .post-attachment img.is-loading {
   filter: blur(15px);


### PR DESCRIPTION
I've noticed that you can get vertical borders on the Scrapbook with photos taking vertically

before:
<img width="395" alt="Screenshot 2020-10-13 at 9 51 27 PM" src="https://user-images.githubusercontent.com/39828164/95869712-40e9f380-0d9e-11eb-8899-3404cf3921fb.png">

after:
<img width="399" alt="Screenshot 2020-10-13 at 9 51 58 PM" src="https://user-images.githubusercontent.com/39828164/95869774-52cb9680-0d9e-11eb-88a7-a72f51dbc756.png">