### PR TITLE
Fix Overlapping Images

### DIFF
--- a/public/themes/default.css
+++ b/public/themes/default.css
@@ -331,7 +331,6 @@ a.post-text-mention {
   margin-top: 16px;
 }
 .post-attachment {
-  width: 100%;
   border-radius: 6px;
   overflow: hidden;
   text-align: center;


### PR DESCRIPTION
When the project switched to `next/image`, some images began to overlap each other on Safari. This is thanks to `next/image`'s unique way of handling sizing of images. 

With this PR, it removes `width: 100%`. After doing so, it will look exactly the same as the pre `next/image` Scrapbook. It has no noticeable side effects, I have checked the home page and one user profile who was using default styles. 

Before (on Safari):

![](https://user-images.githubusercontent.com/39828164/97766927-cc5fd480-1b53-11eb-872e-cbfdb8b9fbe3.png)

After (on Safari):

<img width="1433" alt="Screenshot 2020-10-31 at 11 08 38 AM" src="https://user-images.githubusercontent.com/39828164/97769889-7007af80-1b69-11eb-8002-c52ca578e5d1.png">

<img width="1440" alt="Screenshot 2020-10-31 at 11 10 23 AM" src="https://user-images.githubusercontent.com/39828164/97769917-b52be180-1b69-11eb-981c-0fd379304691.png">

This fixes #115 
