### PR TITLE
Display year on posts

### DIFF
--- a/lib/dates.js
+++ b/lib/dates.js
@@ -119,8 +119,9 @@ const monthNames = [
   'December'
 ].map(m => m.substring(0, 3))
 export const convertTimestampToDate = timestamp => {
+  const today = new Date()
   const isToday =
-    new Date().toISOString().substring(0, 10) ===
+    today.toISOString().substring(0, 10) ===
     timestamp.toString().substring(0, 10)
   let date = new Date(timestamp)
   let week = days[date.getDay()]
@@ -128,6 +129,7 @@ export const convertTimestampToDate = timestamp => {
   let monthIndex = date.getMonth()
   let month = monthNames[monthIndex]
   let year = date.getFullYear()
+  year = year != today.getFullYear() ? `, ${year}` : ""
   let hours = date.getHours() || 0
   let cleanHours
   if (hours === 0) {
@@ -140,5 +142,5 @@ export const convertTimestampToDate = timestamp => {
   let ampm = hours >= 12 ? 'pm' : 'am'
   return isToday
     ? `${cleanHours}:${minutes}${ampm}`
-    : `${week}, ${month} ${day}, ${year}`
+    : `${week}, ${month} ${day}` + year
 }


### PR DESCRIPTION
Scrapbook has been around for over a year now so it's probably a good idea to display the year the post was made in.