### PR TITLE
Add secure.gravatar.com to next config whitelist

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,8 @@ module.exports = withMDX({
       'dl.airtable.com',
       'emoji.slack-edge.com',
       'cloud-lp0r5yk68.vercel.app',
-      'avatars.slack-edge.com'
+      'avatars.slack-edge.com',
+      'secure.gravatar.com',
     ]
   },
   async rewrites() {


### PR DESCRIPTION
This was required to run scrapbook in development for me-- not 100% sure why.