### PR TITLE
Add 50 Days channel keyword

### DIFF
--- a/apps/slack-bot/src/lib/channelKeywords.js
+++ b/apps/slack-bot/src/lib/channelKeywords.js
@@ -29,5 +29,6 @@ export default {
   CDJMS683D: "1234", // #counttoamillion
   CGVCSNLAJ: "first", // #frc
   C064PGB86JE: "quests", // #quests
-  C06CHS2D05Q: "leaders-summit" //#the-summit
+  C06CHS2D05Q: "leaders-summit", //#the-summit
+  C09SWT5DCGY: "50days" // #50-days
 };


### PR DESCRIPTION
this should make :scrappy:'d posts in the #50-days challenge channel get auto-tagged with the :50-days: emoji!