### PR TITLE
fix(web): support wildcard remote patterns for Vercel cloud and bot subdomains

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -32,7 +32,15 @@ let nextConfig = withMDX({
       },
       {
         protocol: 'https',
-        hostname: 'cloud-lp0r5yk68.vercel.app'
+        hostname: 'cloud-*.vercel.app'
+      },
+      {
+        protocol: 'https',
+        hostname: 'cloud-*.hack-club-bot.vercel.app'
+      },
+      {
+        protocol: 'https',
+        hostname: '*-hack-club-bot.vercel.app'
       },
       {
         protocol: 'https',


### PR DESCRIPTION
### Description
This PR fixes broken image attachments on the Scrapbook web app caused by dynamic bot subdomains (e.g., `cloud-jq9igpkbr-hack-club-bot.vercel.app`) not being whitelisted in Next.js `remotePatterns`.

Historically, only a single subdomain (`cloud-lp0r5yk68.vercel.app`, commit: 767eb2a00e9a53e016dccfb9b431c3503f8f086d) was whitelisted in Oct 2020. Since uploader deployments are now dynamic, modern uploads return a `400 Bad Request` from the optimizer.

### Fix
Added wildcard remote patterns in `next.config.js`:
- `cloud-*.vercel.app`
- `cloud-*.hack-club-bot.vercel.app`
- `*-hack-club-bot.vercel.app`

### Verification
1. Start the dev server in `apps/web`: `npm run dev`
2. Fetch a dynamic bot image URL through Next.js optimizer:
   `http://localhost:3000/_next/image?url=https%3A%2F%2Fcloud-jq9igpkbr-hack-club-bot.vercel.app%2F0image.png&w=768&q=75`
3. **Result:** Returns `200 OK` (previously returned `400 Bad Request`).
